### PR TITLE
Introduce Full NFT Protocol with Collateral, Marketplace, Fractional Ownership, and Staking

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,21 +1,23 @@
 [project]
-name = "bitstack-nft"
-description = ""
+name = 'bitstack-nft'
+description = ''
 authors = []
 telemetry = true
-cache_dir = "./.cache"
-
-# [contracts.counter]
-# path = "contracts/counter.clar"
-
+cache_dir = './.cache'
+requirements = []
+[contracts.bitstack-nft]
+path = 'contracts/bitstack-nft.clar'
+clarity_version = 3
+epoch = 3.1
 [repl.analysis]
-passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+passes = ['check_checker']
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false
+
+[repl.remote_data]
+enabled = false
+api_url = 'https://api.hiro.so'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# BitStack NFT Protocol
+
+**Version:** 1.0  
+**Language:** Clarity (Stacks Smart Contract Language)  
+**Secured By:** Bitcoin via Stacks Layer 2
+
+## Overview
+
+**BitStack** is a next-generation NFT protocol deployed on the Stacks blockchain. It integrates advanced DeFi features into the NFT ecosystem, providing robust utility and liquidity options backed by Bitcoin finality. The protocol introduces collateralized NFT minting, a native marketplace, fractional ownership, and staking with yield generation.
+
+## Features
+
+### Collateralized NFT Minting
+
+Mint NFTs by locking STX tokens as collateral. A minimum collateralization ratio ensures economic security and stability.
+
+### On-Chain Marketplace
+
+Buy and sell NFTs directly on-chain with low protocol fees (2.5%). Listings are open and transparent.
+
+### Fractional Ownership via Share Tokens
+
+Split NFT ownership into fungible shares, enabling broader participation and liquidity.
+
+### NFT Staking
+
+Stake NFTs to earn yield paid in STX. Rewards accumulate over time based on a fixed annual yield rate.
+
+### Bitcoin Finality
+
+All transactions achieve finality through Bitcoin via the Stacks consensus mechanism.
+
+## Smart Contract Details
+
+### Constants
+
+- `min-collateral-ratio`: `u150` (150%)
+- `protocol-fee`: `u25` (2.5%)
+- `yield-rate`: `u50` (5% annual, basis points)
+- Error codes defined for access control, validation, and financial integrity
+
+### Data Maps
+
+- `tokens`: NFT metadata including owner, URI, collateral, staking status, and shares
+- `token-listings`: Marketplace records with pricing and status
+- `fractional-ownership`: Share ownership per address per token
+- `staking-rewards`: Tracks accumulated yield and claim timestamps
+
+## Core Functions
+
+### Minting
+
+```clojure
+(mint-nft (uri) (collateral))
+```
+
+Validates URI and STX balance before minting NFT with locked collateral.
+
+### Transfers
+
+```clojure
+(transfer-nft (token-id) (recipient))
+```
+
+Transfers NFT to a recipient, enforcing staking and ownership checks.
+
+### Marketplace
+
+```clojure
+(list-nft (token-id) (price))
+(purchase-nft (token-id))
+```
+
+Enables listing and purchasing of NFTs with enforced price and ownership validation.
+
+### Fractional Ownership
+
+```clojure
+(transfer-shares (token-id) (recipient) (share-amount))
+```
+
+Allows partial transfer of NFT ownership via share tokens.
+
+### Staking
+
+```clojure
+(stake-nft (token-id))
+(unstake-nft (token-id))
+```
+
+Enables and disables staking of NFTs, tracking rewards and timestamp.
+
+### Rewards
+
+```clojure
+(calculate-rewards (token-id))
+```
+
+Read-only function to compute staking rewards based on block time and yield rate.
+
+## Helper Functions
+
+### URI & Recipient Validation
+
+- `validate-uri`: Ensures URI is a valid ASCII string
+- `validate-recipient`: Prevents self-transfer to the contract
+
+### Math Safety
+
+- `safe-add`: Prevents overflow in share calculations
+
+## Deployment Notes
+
+- Requires deployment on the Stacks blockchain
+- Contract owner is defined as the deployer (`tx-sender`)
+- Protocol fees are transferred to the contract treasury for sustainability
+
+## Security Considerations
+
+- Overflow-safe arithmetic
+- Access-controlled functions (owner and token-holder only)
+- Immutable rules enforced at protocol level (e.g. staking, transfers)

--- a/contracts/bitstack-nft.clar
+++ b/contracts/bitstack-nft.clar
@@ -1,0 +1,79 @@
+;; Title: BitStack NFT Protocol
+;;
+;; Summary:
+;; A comprehensive NFT platform built on Stacks with collateralized assets, marketplace
+;; functionality, fractional ownership, and staking rewards - all secured by Bitcoin.
+;;
+;; Description:
+;; This smart contract implements a next-generation NFT protocol that enables users to:
+;; - Mint NFTs with STX collateral backing
+;; - Trade NFTs on an integrated marketplace with low protocol fees
+;; - Fractionalize ownership to increase liquidity
+;; - Earn yield through NFT staking
+;; All operations are settled with finality on Bitcoin through the Stacks Layer 2 architecture.
+
+;; Constants & Error Codes
+
+(define-constant contract-owner tx-sender)
+
+;; Access Control
+(define-constant err-owner-only (err u100))
+(define-constant err-not-token-owner (err u101))
+
+;; Financial
+(define-constant err-insufficient-balance (err u102))
+(define-constant err-insufficient-collateral (err u106))
+
+;; NFT Operations
+(define-constant err-invalid-token (err u103))
+(define-constant err-listing-not-found (err u104))
+(define-constant err-invalid-price (err u105))
+
+;; Staking
+(define-constant err-already-staked (err u107))
+(define-constant err-not-staked (err u108))
+
+;; Validation
+(define-constant err-invalid-percentage (err u109))
+(define-constant err-invalid-uri (err u110))
+(define-constant err-invalid-recipient (err u111))
+(define-constant err-overflow (err u112))
+
+;; Protocol Configuration
+
+(define-data-var min-collateral-ratio uint u150)  ;; 150% minimum collateral ratio
+(define-data-var protocol-fee uint u25)           ;; 2.5% fee in basis points
+(define-data-var total-staked uint u0)
+(define-data-var yield-rate uint u50)             ;; 5% annual yield rate in basis points
+(define-data-var total-supply uint u0)
+
+;; Data Maps
+
+;; Core NFT Data
+(define-map tokens
+    { token-id: uint }
+    {
+        owner: principal,
+        uri: (string-ascii 256),
+        collateral: uint,
+        is-staked: bool,
+        stake-timestamp: uint,
+        fractional-shares: uint
+    }
+)
+
+;; Marketplace Listings
+(define-map token-listings
+    { token-id: uint }
+    {
+        price: uint,
+        seller: principal,
+        active: bool
+    }
+)
+
+;; Fractional Ownership Records
+(define-map fractional-ownership
+    { token-id: uint, owner: principal }
+    { shares: uint }
+)

--- a/contracts/bitstack-nft.clar
+++ b/contracts/bitstack-nft.clar
@@ -157,3 +157,83 @@
         (ok true)
     )
 )
+
+;; Marketplace Functions
+
+(define-public (list-nft (token-id uint) (price uint))
+    (let
+        (
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+        )
+        (asserts! (> price u0) err-invalid-price)
+        (asserts! (is-eq tx-sender (get owner token)) err-not-token-owner)
+        (asserts! (not (get is-staked token)) err-already-staked)
+        (map-set token-listings
+            { token-id: token-id }
+            {
+                price: price,
+                seller: tx-sender,
+                active: true
+            }
+        )
+        (ok true)
+    )
+)
+
+(define-public (purchase-nft (token-id uint))
+    (let
+        (
+            (listing (unwrap! (get-listing token-id) err-listing-not-found))
+            (price (get price listing))
+            (seller (get seller listing))
+            (fee (/ (* price (var-get protocol-fee)) u1000))
+        )
+        (asserts! (get active listing) err-listing-not-found)
+        
+        ;; Transfer STX from buyer to seller
+        (try! (stx-transfer? price tx-sender seller))
+        ;; Transfer protocol fee
+        (try! (stx-transfer? fee tx-sender (as-contract tx-sender)))
+        
+        ;; Update token ownership
+        (try! (transfer-nft token-id tx-sender))
+        
+        ;; Clear listing
+        (map-set token-listings
+            { token-id: token-id }
+            {
+                price: u0,
+                seller: seller,
+                active: false
+            }
+        )
+        (ok true)
+    )
+)
+
+;; Fractional Ownership Functions
+
+(define-public (transfer-shares (token-id uint) (recipient principal) (share-amount uint))
+    (let
+        (
+            (sender-shares (unwrap! (get-fractional-shares token-id tx-sender) err-insufficient-balance))
+            (current-recipient-shares (default-to { shares: u0 } (get-fractional-shares token-id recipient)))
+            (recipient-new-shares (unwrap! (safe-add (get shares current-recipient-shares) share-amount) err-overflow))
+        )
+        (asserts! (validate-recipient recipient) err-invalid-recipient)
+        (asserts! (>= (get shares sender-shares) share-amount) err-insufficient-balance)
+        
+        ;; Update sender's shares
+        (map-set fractional-ownership
+            { token-id: token-id, owner: tx-sender }
+            { shares: (- (get shares sender-shares) share-amount) }
+        )
+        
+        ;; Update recipient's shares
+        (map-set fractional-ownership
+            { token-id: token-id, owner: recipient }
+            { shares: recipient-new-shares }
+        )
+        (ok true)
+    )
+)

--- a/contracts/bitstack-nft.clar
+++ b/contracts/bitstack-nft.clar
@@ -237,3 +237,110 @@
         (ok true)
     )
 )
+
+;; Staking Functions
+
+(define-public (stake-nft (token-id uint))
+    (let
+        (
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+        )
+        (asserts! (is-eq tx-sender (get owner token)) err-not-token-owner)
+        (asserts! (not (get is-staked token)) err-already-staked)
+        
+        (map-set tokens
+            { token-id: token-id }
+            (merge token { 
+                is-staked: true,
+                stake-timestamp: stacks-block-height
+            })
+        )
+        (map-set staking-rewards
+            { token-id: token-id }
+            {
+                accumulated-yield: u0,
+                last-claim: stacks-block-height
+            }
+        )
+        (var-set total-staked (+ (var-get total-staked) u1))
+        (ok true)
+    )
+)
+
+(define-public (unstake-nft (token-id uint))
+    (let
+        (
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+            (rewards (unwrap! (get-staking-rewards token-id) err-not-staked))
+        )
+        (asserts! (is-eq tx-sender (get owner token)) err-not-token-owner)
+        (asserts! (get is-staked token) err-not-staked)
+        
+        ;; Calculate and distribute final rewards
+        (try! (claim-staking-rewards token-id))
+        
+        (map-set tokens
+            { token-id: token-id }
+            (merge token { 
+                is-staked: false,
+                stake-timestamp: u0
+            })
+        )
+        (var-set total-staked (- (var-get total-staked) u1))
+        (ok true)
+    )
+)
+
+;; Read-Only Functions
+
+(define-read-only (get-token-info (token-id uint))
+    (map-get? tokens { token-id: token-id })
+)
+
+(define-read-only (get-listing (token-id uint))
+    (map-get? token-listings { token-id: token-id })
+)
+
+(define-read-only (get-fractional-shares (token-id uint) (owner principal))
+    (map-get? fractional-ownership { token-id: token-id, owner: owner })
+)
+
+(define-read-only (get-staking-rewards (token-id uint))
+    (map-get? staking-rewards { token-id: token-id })
+)
+
+(define-read-only (calculate-rewards (token-id uint))
+    (let
+        (
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+            (rewards (unwrap! (get-staking-rewards token-id) err-not-staked))
+            (blocks-staked (- stacks-block-height (get stake-timestamp token)))
+            (yield-per-block (/ (var-get yield-rate) u52560)) ;; Approximate blocks per year
+            (new-rewards (* blocks-staked yield-per-block))
+        )
+        (ok (+ (get accumulated-yield rewards) new-rewards))
+    )
+)
+
+;; Private Reward Functions
+
+(define-private (claim-staking-rewards (token-id uint))
+    (let
+        (
+            (rewards (unwrap! (calculate-rewards token-id) err-not-staked))
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+        )
+        (asserts! (get is-staked token) err-not-staked)
+        
+        (map-set staking-rewards
+            { token-id: token-id }
+            {
+                accumulated-yield: u0,
+                last-claim: stacks-block-height
+            }
+        )
+        
+        ;; Transfer rewards in STX
+        (as-contract (stx-transfer? rewards (as-contract tx-sender) (get owner token)))
+    )
+)

--- a/contracts/bitstack-nft.clar
+++ b/contracts/bitstack-nft.clar
@@ -77,3 +77,83 @@
     { token-id: uint, owner: principal }
     { shares: uint }
 )
+
+;; Staking Rewards Tracking
+(define-map staking-rewards
+    { token-id: uint }
+    { 
+        accumulated-yield: uint,
+        last-claim: uint
+    }
+)
+
+;; Private Helper Functions
+
+(define-private (validate-uri (uri (string-ascii 256)))
+    (let
+        (
+            (uri-len (len uri))
+        )
+        (and
+            (> uri-len u0)
+            (<= uri-len u256)
+        )
+    )
+)
+
+(define-private (validate-recipient (recipient principal))
+    (not (is-eq recipient (as-contract tx-sender)))
+)
+
+(define-private (safe-add (a uint) (b uint))
+    (let
+        (
+            (sum (+ a b))
+        )
+        (asserts! (>= sum a) err-overflow)
+        (ok sum)
+    )
+)
+
+;; Core NFT Functions
+
+(define-public (mint-nft (uri (string-ascii 256)) (collateral uint))
+    (let
+        (
+            (token-id (+ (var-get total-supply) u1))
+            (collateral-requirement (/ (* (var-get min-collateral-ratio) collateral) u100))
+        )
+        (asserts! (validate-uri uri) err-invalid-uri)
+        (asserts! (>= (stx-get-balance tx-sender) collateral-requirement) err-insufficient-collateral)
+        (try! (stx-transfer? collateral-requirement tx-sender (as-contract tx-sender)))
+        (map-set tokens
+            { token-id: token-id }
+            {
+                owner: tx-sender,
+                uri: uri,
+                collateral: collateral,
+                is-staked: false,
+                stake-timestamp: u0,
+                fractional-shares: u0
+            }
+        )
+        (var-set total-supply token-id)
+        (ok token-id)
+    )
+)
+
+(define-public (transfer-nft (token-id uint) (recipient principal))
+    (let
+        (
+            (token (unwrap! (get-token-info token-id) err-invalid-token))
+        )
+        (asserts! (validate-recipient recipient) err-invalid-recipient)
+        (asserts! (is-eq tx-sender (get owner token)) err-not-token-owner)
+        (asserts! (not (get is-staked token)) err-already-staked)
+        (map-set tokens
+            { token-id: token-id }
+            (merge token { owner: recipient })
+        )
+        (ok true)
+    )
+)

--- a/tests/bitstack-nft.test.ts
+++ b/tests/bitstack-nft.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initialised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
**Description:**

This PR introduces the complete implementation of the BitStack NFT Protocol, a Bitcoin-secured NFT system on Stacks that supports collateralized minting, on-chain trading, fractional ownership, and yield-generating staking.

### New Features

- **NFT Minting & Transfers**
  - `mint-nft`: Mint NFTs with STX collateral and URI validation.
  - `transfer-nft`: Transfer ownership of NFTs, restricted to unstaked tokens.

- **Marketplace**
  - `list-nft`: List NFTs for sale with ownership and staking validation.
  - `purchase-nft`: Purchase listed NFTs, with STX transfers and fee deduction.

- **Fractional Ownership**
  - `fractional-ownership` map: Tracks share ownership per NFT per principal.
  - `transfer-shares`: Transfer fractional shares with overflow-safe math and validations.

- **Staking & Rewards**
  - `stake-nft` / `unstake-nft`: Stake NFTs to earn yield based on block duration.
  - `calculate-rewards`: Read-only function to estimate accumulated staking rewards.
  - `claim-staking-rewards`: Internal handler to distribute STX yield to NFT owners.

- **Protocol Parameters**
  - Configurable `min-collateral-ratio`, `protocol-fee`, and `yield-rate`.

### Documentation
- Added a complete README with:
  - Protocol overview and technical details
  - Descriptions of features, data structures, functions, and deployment guidance
  - Security considerations and usage examples

### Impact
- Establishes a fully operational NFT platform with DeFi-grade capabilities.
- Enables liquidity, incentivization, and composability on top of NFTs.
- Lays the foundation for future modules like auctions, DAO governance, or NFT-backed loans.

**Reviewer Notes:**
- All smart contract functions are access-controlled and validated for security.
- Overflow checks and recipient validations are included where necessary.
- Recommend reviewing staking reward math and marketplace logic for edge cases.